### PR TITLE
Develop - fixed mavros error in simple_pilot and pilot.cpp - added mavros_msgs include and CommandCode

### DIFF
--- a/docs/Change History.md
+++ b/docs/Change History.md
@@ -2,6 +2,11 @@
 
 This project uses [semantic versioning](http://semver.org/).
 
+## v0.4.0 - 2015/10/01
+
+* Fixed `CMD_DO_SET_SERVO` is not a member compile error
+* Added documentation for pre-made SD card image
+
 ## v0.3.0 - 2015/06/23
 
 * Updated document ahead of public announcement

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -49,7 +49,17 @@ We are using a RaspberryPi 2 as our embedded ROV computer. We recommend installi
 
 ### Flashing an SD Card with Ubuntu
 
-Follow [these instructions](https://wiki.ubuntu.com/ARM/RaspberryPi) to flash Ubuntu onto an SD card for the RaspberryPi. Once the install has completed, use a keyboard and monitor to complete the partition resizing and OS essentials section. The username and password for the standard Ubuntu image is `ubuntu:ubuntu`. After the SSH server has been installed, you can work remotely.
+Follow [these instructions](https://wiki.ubuntu.com/ARM/RaspberryPi) to flash Ubuntu onto an SD card for the RaspberryPi. 
+
+```bash
+cd ~/Downloads
+http://www.finnie.org/software/raspberrypi/2015-04-06-ubuntu-trusty.zip
+df -h # determine the file path of the SD card, /dev/sdb in this case
+eject /dev/sdb
+sudo bmaptool copy --bmap ~/Downloads/2015-04-06-ubuntu-trusty.bmap ~/Downloads/2015-04-06-ubuntu-trusty.img /dev/sdb
+```
+
+Once the install has completed, use a keyboard and monitor to complete the partition resizing and to set up networking. The username and password for the standard Ubuntu image is `ubuntu:ubuntu`. After the SSH server has been installed, you can work remotely.
 
 There are no Raspbian-specific utilities included, specifically no automatic root resizer. However, it's not hard to do manually. Once booted, you'll need to resize the primary partition and create a swapfile:
 
@@ -63,27 +73,12 @@ sudo fdisk /dev/mmcblk0
 sudo shutdown -r now
 
 sudo resize2fs /dev/mmcblk0p2
-sudo apt-get install dphys-swapfile # this step might take a while
 ```
 
 You can use `dh -f` to verify the partition has been resized.
 
 If you get stuck, this [elinux page](http://elinux.org/RPi_Resize_Flash_Partitions#Manually_resizing_the_SD_card_on_Linux
 https://www.raspberrypi.org/forums/viewtopic.php?f=91&t=24993) is also a good resource for flashing SD cards.
-
-### Setup OS Essentials
-
-```bash
-sudo hostname bluerov
-sudo sh -c 'echo "bluerov" > /etc/hostname'
-
-sudo apt-get update
-sudo apt-get install libraspberrypi-bin libraspberrypi-dev openssh-server wpasupplicant git build-essential avahi-daemon screen linux-firmware -y
-sudo apt-get upgrade
-
-# some libraries require the libraspberrypi-bin and libraspberrypi-dev files at /opt/vc
-sudo ln -s /usr /opt/vc
-```
 
 ### ROV Wifi Network Setup
 
@@ -123,6 +118,20 @@ ping google.com
 ```
 
 For more information, check out [this guide](https://kerneldriver.wordpress.com/2012/10/21/configuring-wpa2-using-wpa_supplicant-on-the-raspberry-pi/).
+
+### Setup OS Essentials
+
+```bash
+sudo hostname bluerov
+sudo sh -c 'echo "bluerov" > /etc/hostname'
+
+sudo apt-get update
+sudo apt-get install dphys-swapfile libraspberrypi-bin libraspberrypi-dev openssh-server wpasupplicant git build-essential avahi-daemon screen linux-firmware -y
+sudo apt-get upgrade
+
+# some libraries require the libraspberrypi-bin and libraspberrypi-dev files at /opt/vc
+sudo ln -s /usr /opt/vc
+```
 
 ## ROV APM Setup
 
@@ -237,7 +246,7 @@ Check out [this syntax guide](http://www.reactivated.net/writing_udev_rules.html
 
 ## Direct Network Configuration
 
-When performing tele-operated tests and missions, it can be desirable to connect the workstation and ROV together using a direct Ethernet connection. Wifi connectivity obviously isn't an option through water, and a direct Ethernet connection eliminates the need for a network switch between the two computers.
+When performing tele-operated tests and missions, it can be desirable to connect the workstation and ROV together using a direct Ethernet connection. Wifi connectivity obviously isn't an option through water and a direct Ethernet connection eliminates the need for a network switch between the two computers.
 
 On the workstation machine, choose an Ethernet interface to dedicate to the ROV. We will use `eth0`. Modify the file `/etc/network/interfaces` by adding or replacing the following information for your chosen interface:
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -43,7 +43,28 @@ For reference, the hostname on the VM defaults to `c3po` with the username:passw
 
 ProTip: If you decide to use a shared folder between your host machine and the VM, be sure to run `sudo usermod -aG vboxsf $(whoami)` and restart or login/logout in order to have write privileges in the shared folder from the VM.
 
-## ROV Preparation
+## ROV Preparation from SD Card Image
+
+An image containing a working version of Ubuntu and the BlueROV software is available for your convenience. If you choose this route, you may skip the "ROV Preparation from Clean Ubuntu Install" section and continue on with the rest of the setup.
+
+```bash
+# get the image
+cd ~/Downloads
+wget http://SOME_HOST/2015-10-01-bluerov-ros-indigo-0.4.0.zip
+sudo apt-get install unzip
+unzip 2015-10-01-bluerov-ros-indigo-0.4.0.zip
+
+# prepare the install destination
+df -h # determine the file path of the SD card, /dev/sdb in this case
+eject /dev/sdb
+
+# install the image
+sudo bmaptool copy --bmap ~/Downloads/2015-10-01-bluerov-ros-indigo-0.4.0.bmap ~/Downloads/2015-10-01-bluerov-ros-indigo-0.4.0.img /dev/sdb
+```
+
+One the image is installed, you can install the card into the ROV, power it up, and immediately begin communicating the the ROV using the Ethernet tether. See the "Network Configuration for Tether" section for instructions on how to configure your workstation computer for the tether connection. You can also configure your ROV for above-surface Wifi communication per the Wifi network setup section below.
+
+## ROV Preparation from Clean Ubuntu Install
 
 We are using a RaspberryPi 2 as our embedded ROV computer. We recommend installing Ubuntu 14.04 on the RaspberryPi over Rasbian OS because of the ease of installing ROS packages. On Ubuntu, packages can be installed as binaries from `apt`, but on Rasbian, most packages must be installed from source.
 
@@ -52,10 +73,17 @@ We are using a RaspberryPi 2 as our embedded ROV computer. We recommend installi
 Follow [these instructions](https://wiki.ubuntu.com/ARM/RaspberryPi) to flash Ubuntu onto an SD card for the RaspberryPi. 
 
 ```bash
+# get the image
 cd ~/Downloads
-http://www.finnie.org/software/raspberrypi/2015-04-06-ubuntu-trusty.zip
+wget http://www.finnie.org/software/raspberrypi/2015-04-06-ubuntu-trusty.zip
+sudo apt-get install unzip
+unzip 2015-04-06-ubuntu-trusty.zip
+
+# prepare the install destination
 df -h # determine the file path of the SD card, /dev/sdb in this case
 eject /dev/sdb
+
+# install the image
 sudo bmaptool copy --bmap ~/Downloads/2015-04-06-ubuntu-trusty.bmap ~/Downloads/2015-04-06-ubuntu-trusty.img /dev/sdb
 ```
 
@@ -80,9 +108,25 @@ You can use `dh -f` to verify the partition has been resized.
 If you get stuck, this [elinux page](http://elinux.org/RPi_Resize_Flash_Partitions#Manually_resizing_the_SD_card_on_Linux
 https://www.raspberrypi.org/forums/viewtopic.php?f=91&t=24993) is also a good resource for flashing SD cards.
 
+### Setup OS Essentials
+
+A network connection with Internet access is required for this section. Since we haven't yet set up a Wifi connection, please connection using an Ethernet connection.
+
+```bash
+sudo hostname bluerov
+sudo sh -c 'echo "bluerov" > /etc/hostname'
+
+sudo apt-get update
+sudo apt-get install dphys-swapfile libraspberrypi-bin libraspberrypi-dev openssh-server wpasupplicant git build-essential avahi-daemon screen linux-firmware -y
+sudo apt-get upgrade -y
+
+# some libraries require the libraspberrypi-bin and libraspberrypi-dev files at /opt/vc
+sudo ln -s /usr /opt/vc
+```
+
 ### ROV Wifi Network Setup
 
-Setting up Wifi on your ROV machine will enable easy development and will leave your Ethernet port free for direct connection use (see below.)
+Setting up Wifi on your ROV machine will enable easy development and will leave your Ethernet port free for a direct connection to a surface computer (see below.)
 
 First, write your network connection details to `/etc/wpa_supplicant/wpa_supplicant.conf`:
 
@@ -119,18 +163,34 @@ ping google.com
 
 For more information, check out [this guide](https://kerneldriver.wordpress.com/2012/10/21/configuring-wpa2-using-wpa_supplicant-on-the-raspberry-pi/).
 
-### Setup OS Essentials
+### ROV Camera Configuration
+
+To get the camera working in Ubuntu 14.04:
 
 ```bash
-sudo hostname bluerov
-sudo sh -c 'echo "bluerov" > /etc/hostname'
+sudo sh -c 'echo "start_x=1\ngpu_mem=128" >> /boot/config.txt'
+# sudo apt-get install libraspberrypi-dev libraspberrypi-bin
+sudo shutdown -r now
+raspistill -o test.jpg
+scp ubuntu@bluerov:~/test.jpg ~/
+```
+
+For more information, check out [this forum post](https://www.raspberrypi.org/forums/viewtopic.php?f=56&t=100553).
+
+### ROV ROS Installation
+
+```bash
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
 
 sudo apt-get update
-sudo apt-get install dphys-swapfile libraspberrypi-bin libraspberrypi-dev openssh-server wpasupplicant git build-essential avahi-daemon screen linux-firmware -y
-sudo apt-get upgrade
+sudo apt-get install ros-indigo-ros-base -y
 
-# some libraries require the libraspberrypi-bin and libraspberrypi-dev files at /opt/vc
-sudo ln -s /usr /opt/vc
+sudo rosdep init
+rosdep update
+
+echo "source /opt/ros/indigo/setup.bash" >> ~/.bashrc
+source ~/.bashrc
 ```
 
 ## ROV APM Setup
@@ -150,36 +210,6 @@ make upload
 ```
 
 Note to self: In the future, try out a PX4 with the "OFFBOARD" mode.
-
-### ROV Camera Configuration
-
-To get the camera working in Ubuntu 14.04:
-
-```bash
-sudo sh -c 'echo "start_x=1\ngpu_mem=128" >> /boot/config.txt'
-sudo apt-get install libraspberrypi-dev libraspberrypi-bin
-sudo shutdown -r now
-raspistill -o test.jpg
-scp ubuntu@bluerov:~/test.jpg ~/
-```
-
-For more information, check out [this forum post](https://www.raspberrypi.org/forums/viewtopic.php?f=56&t=100553).
-
-### ROV ROS Installation
-
-```bash
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
-
-sudo apt-get update
-sudo apt-get install ros-indigo-ros-base
-
-sudo rosdep init
-rosdep update
-
-echo "source /opt/ros/indigo/setup.bash" >> ~/.bashrc
-source ~/.bashrc
-```
 
 ## BlueROV ROS Package Installation
 
@@ -215,7 +245,7 @@ source ~/.bashrc
 echo $ROS_PACKAGE_PATH
 ```
 
-Then install the `bluerov` package rebuild:
+Then install the `bluerov` package and recompile:
 
 ```bash
 cd ~/catkin_ws/src/
@@ -244,7 +274,7 @@ sudo udevadm trigger # to immediately reload the rules without restarting
 
 Check out [this syntax guide](http://www.reactivated.net/writing_udev_rules.html#syntax) for creating new udev rules.
 
-## Direct Network Configuration
+## Network Configuration for Tether
 
 When performing tele-operated tests and missions, it can be desirable to connect the workstation and ROV together using a direct Ethernet connection. Wifi connectivity obviously isn't an option through water and a direct Ethernet connection eliminates the need for a network switch between the two computers.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ This package is designed to work with a variety of ROV platforms, but is focused
 * A surface computer running Ubuntu (through a virtual machine is OK)
 * An input device for manual control attached to the surface computer
     - We are using a [wireless Xbox 360 controller](http://www.amazon.com/Xbox-360-Wireless-Controller-Black/dp/B00FYWYJ2E/ref=sr_1_2?s=electronics&ie=UTF8&qid=1434390319&sr=1-2&keywords=xbox+360+wireless+controller) and [USB dongle](http://www.amazon.com/Xbox-Wireless-Gaming-Receiver-Windows/dp/B000HZFCT2/ref=sr_1_9?s=electronics&ie=UTF8&qid=1434390346&sr=1-9&keywords=xbox+360+wireless+controller+usb)
-* An on-board computer running Ubuntu
+* An on-board computer running Ubuntu w/ Ethernet port for tether
     - We are using a [RaspberryPi 2 B](https://www.raspberrypi.org/products/raspberry-pi-2-model-b/)
 * An on-board camera
     - We are using a [RaspberryPi Camera](https://www.raspberrypi.org/products/camera-module/)

--- a/src/simple_pilot.cpp
+++ b/src/simple_pilot.cpp
@@ -76,7 +76,7 @@ void Pilot::setServo(int index, float value) {
   // http://docs.ros.org/api/mavros/html/srv/CommandLong.html
   // CMD_DO_SET_SERVO (183): https://pixhawk.ethz.ch/mavlink/
   mavros::CommandLong srv;
-  srv.request.command = mavros::CommandLongRequest::CMD_DO_SET_SERVO;
+  srv.request.command = 183; //mavros::CommandLongRequest::CMD_DO_SET_SERVO;
   srv.request.param1 = index + 1; // servos are 1-indexed here
   srv.request.param2 = pulse_width;
   bool result = command_client.call(srv);


### PR DESCRIPTION
…include and CommandCode.

Details: Seems like there was a change to mavros over the last few months. When building on the RPi, noticed build failed giving ActuatorCommand.h not found. Discovered that both ActuatorCommand and CommandLong now live in mavros_msgs:: and not mavros:: scope. Modified both simple_pilot and pilot.cpp for new scoping as well as changed CommandLongRequest to CommandCode for line 79 of simple_pilot: mavros_msgs::CommandCode::CMD_DO_SET_SERVO. Also added include mavros_msgs/CommandCode.h to handle command codes properly.
