### PR TITLE
Build failure fix for bluerov_apps CMakeLists.txt

### DIFF
--- a/bluerov_apps/CMakeLists.txt
+++ b/bluerov_apps/CMakeLists.txt
@@ -7,8 +7,6 @@ project(bluerov_apps)
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   nav_msgs
-  pcl_conversions
-  pcl_ros
   roscpp
   rospy
   std_msgs
@@ -38,7 +36,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES bluerov_apps
-#  CATKIN_DEPENDS geometry_msgs nav_msgs pcl_conversions pcl_ros roscpp std_msgs tf
+#  CATKIN_DEPENDS geometry_msgs nav_msgs roscpp std_msgs tf
 #  DEPENDS system_lib
 )
 

--- a/bluerov_apps/package.xml
+++ b/bluerov_apps/package.xml
@@ -13,8 +13,6 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>joy</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>pcl_conversions</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -23,8 +21,6 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>joy</run_depend>
   <run_depend>nav_msgs</run_depend>
-  <run_depend>pcl_conversions</run_depend>
-  <run_depend>pcl_ros</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
added dynamic_reconfigure to find package to fix build issue

The dynamic reconfigure required component was not in the find package line of the cmake, causing a build failure when

generate_dynamic_reconfigure_options(
  cfg/teleop_joy.cfg
)

was read.
